### PR TITLE
update linter, remove unneeded devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,32 +46,18 @@
   },
   "devDependencies": {
     "@iobroker/adapter-dev": "^1.5.0",
+    "@iobroker/eslint-config": "^2.2.0",
     "@iobroker/testing": "^5.2.2",
     "@types/node": "^24.10.1",
-    "eslint": "^9.34.0",
-    "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-prettier": "^5.5.4",
-    "prettier": "^3.7.4",
     "typescript": "~5.9.3",
-    "@iobroker/eslint-config": "^2.2.0",
-    "@eslint/js": "^9.34.0",
-    "@eslint/eslintrc": "^3.3.1",
-    "eslint-plugin-import": "^2.30.0",
-    "eslint-plugin-jsdoc": "^54.1.1",
-    "eslint-plugin-unicorn": "^60.0.0",
-    "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^5.2.0",
-    "globals": "^16.3.0",
-    "@typescript-eslint/eslint-plugin": "^8.40.0",
-    "@typescript-eslint/parser": "^8.40.0",
-    "typescript-eslint": "^8.40.0"
+    "globals": "^16.3.0"
   },
   "scripts": {
     "test:js": "node scripts/run-mocha.js --config test/mocharc.custom.json \"{!(node_modules|test)/**/*.test.js,*.test.js,test/**/test!(PackageFiles|Startup).js}\"",
     "test:package": "node scripts/run-mocha.js test/package --exit",
     "test:integration": "node scripts/run-mocha.js test/integration --exit",
     "test": "npm run test:js && npm run test:package",
-    "lint": "eslint .",
+    "lint": "eslint -c eslint.config.mjs .",
     "postinstall": "node scripts/postinstall.js"
   }
 }


### PR DESCRIPTION
This PR removes unneeded devDependencies.

All linter / prettier modules are normally provided by usage of @opbroker/eslint-config. Adding eslint / prettier packages locally is normally not needed and might cause problems.

